### PR TITLE
Feat: filter #02

### DIFF
--- a/src/filter.ts
+++ b/src/filter.ts
@@ -1,0 +1,13 @@
+import { isPerceivable } from './isPerceivable'
+import type { ColorTuple, deltaValueType } from './types'
+
+interface FilterOptions {
+  threshold?: number
+  type?: deltaValueType
+}
+
+export function filter<T extends any[]>(comparitor: string | ColorTuple, filterList: T, options?: FilterOptions): any[] {
+  options = { threshold: 5, type: 'rgb', ...options }
+
+  return filterList.filter(color => isPerceivable(comparitor as any, color, options))
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,5 +4,6 @@ export * from './isPerceivable'
 export * from './sampleImage'
 export * from './selector'
 export * from './types'
+export * from './filter'
 export { toHSLString, toRBGString } from './utils'
 

--- a/test/filter.test.ts
+++ b/test/filter.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { isArray } from 'yewtils'
+import { filter } from '../src'
+
+describe('filter', ()=>{
+    it('should return an array', ()=>{
+        expect(isArray(filter('#000',['#fff','#fff','#fff']))).toBeTruthy()
+    })
+    it('should not mutate original array', ()=>{
+        const arr = ['#fff','#fff','#000']
+        filter('#000', arr)
+        expect(arr).toHaveLength(3)
+    })
+    it('should return a filtered array', ()=>{
+        const arr = ['#fff','#fff','#000']
+        const result = filter('#000', arr)
+        expect(result).toHaveLength(2)
+        expect(result).toMatchObject(["#fff","#fff"])
+    })
+    it('should be able to customise threshold', ()=>{
+        const arr = ['#fff','#777','#000']
+        const result = filter('#000', arr)
+        expect(result).toHaveLength(2)
+        expect(result).toMatchObject(['#fff','#777'])
+        expect(filter('#000', arr, {threshold: 50})).toHaveLength(1)
+        expect(filter('#000', arr, {threshold: 50})).toMatchObject(['#fff'])
+    })
+    it('should be accept and filter any color type', ()=>{
+        const arr = ['#fff','hsl(0,50%,50%)','rgb(0,0,0)', [0,0,0]]
+        const result = filter('#000', arr, {type: 'rgb'})
+        expect(result).toHaveLength(2)
+        expect(result).toMatchObject(["#fff","hsl(0,50%,50%)"])
+    })
+})

--- a/test/filter.test.ts
+++ b/test/filter.test.ts
@@ -2,33 +2,33 @@ import { describe, expect, it } from 'vitest'
 import { isArray } from 'yewtils'
 import { filter } from '../src'
 
-describe('filter', ()=>{
-    it('should return an array', ()=>{
-        expect(isArray(filter('#000',['#fff','#fff','#fff']))).toBeTruthy()
-    })
-    it('should not mutate original array', ()=>{
-        const arr = ['#fff','#fff','#000']
-        filter('#000', arr)
-        expect(arr).toHaveLength(3)
-    })
-    it('should return a filtered array', ()=>{
-        const arr = ['#fff','#fff','#000']
-        const result = filter('#000', arr)
-        expect(result).toHaveLength(2)
-        expect(result).toMatchObject(["#fff","#fff"])
-    })
-    it('should be able to customise threshold', ()=>{
-        const arr = ['#fff','#777','#000']
-        const result = filter('#000', arr)
-        expect(result).toHaveLength(2)
-        expect(result).toMatchObject(['#fff','#777'])
-        expect(filter('#000', arr, {threshold: 50})).toHaveLength(1)
-        expect(filter('#000', arr, {threshold: 50})).toMatchObject(['#fff'])
-    })
-    it('should be accept and filter any color type', ()=>{
-        const arr = ['#fff','hsl(0,50%,50%)','rgb(0,0,0)', [0,0,0]]
-        const result = filter('#000', arr, {type: 'rgb'})
-        expect(result).toHaveLength(2)
-        expect(result).toMatchObject(["#fff","hsl(0,50%,50%)"])
-    })
+describe('filter', () => {
+  it('should return an array', () => {
+    expect(isArray(filter('#000', ['#fff', '#fff', '#fff']))).toBeTruthy()
+  })
+  it('should not mutate original array', () => {
+    const arr = ['#fff', '#fff', '#000']
+    filter('#000', arr)
+    expect(arr).toHaveLength(3)
+  })
+  it('should return a filtered array', () => {
+    const arr = ['#fff', '#fff', '#000']
+    const result = filter('#000', arr)
+    expect(result).toHaveLength(2)
+    expect(result).toMatchObject(['#fff', '#fff'])
+  })
+  it('should be able to customise threshold', () => {
+    const arr = ['#fff', '#777', '#000']
+    const result = filter('#000', arr)
+    expect(result).toHaveLength(2)
+    expect(result).toMatchObject(['#fff', '#777'])
+    expect(filter('#000', arr, { threshold: 50 })).toHaveLength(1)
+    expect(filter('#000', arr, { threshold: 50 })).toMatchObject(['#fff'])
+  })
+  it('should be accept and filter any color type', () => {
+    const arr = ['#fff', 'hsl(0,50%,50%)', 'rgb(0,0,0)', [0, 0, 0]]
+    const result = filter('#000', arr, { type: 'rgb' })
+    expect(result).toHaveLength(2)
+    expect(result).toMatchObject(['#fff', 'hsl(0,50%,50%)'])
+  })
 })


### PR DESCRIPTION
implement filter function implementation

```typescript
const filtered = filter('#dd2244', ['#dd2244' ,'#e83b3b', '#45b0b0'], { 
   threshold: 10, // default is 5
   type: 'hex', // only really needed if including tuples
})

console.log(filtered) // ['#dd2244', '#45b0b0']
```

pass a base comparitor color as first argument and then array of other colors, these can be any color string, or a tuple.

can also pass an options object to change the threshold of the comparison and the type of any tuples

