### PR TITLE
feat: sort #3

### DIFF
--- a/src/deltaE.ts
+++ b/src/deltaE.ts
@@ -1,13 +1,9 @@
-import { isArray, isString } from 'yewtils'
-import type { ColorTuple, RGBColorTuple, deltaValueType } from './types'
-import { getStringColorConvertion, getTupleColorConvertion } from './utils'
+import { isString } from 'yewtils'
+import type { ColorTuple, deltaValueType } from './types'
+import { getStringColorConvertion, getTupleColorConvertion, isColorTuple } from './utils'
 
 // cache imput colors to save calculations
 const deltaCache = new Map<string, number>()
-
-function isColorTuple(possibleColorTuple: unknown): possibleColorTuple is RGBColorTuple {
-  return isArray(possibleColorTuple) && possibleColorTuple.length === 3
-}
 
 /**
  * takes two colors and measure of change in visual perception of the two given colors, returns delta-e value 0 - 100+
@@ -23,13 +19,13 @@ export function deltaE(color1: unknown, color2: unknown, type: unknown): number 
   if (isString(color1))
     color1 = getStringColorConvertion(color1)
   else if (isColorTuple(color1))
-    color1 = getTupleColorConvertion(color1, type as Exclude<deltaValueType, 'hex'>)
+    color1 = getTupleColorConvertion(color1, type as Exclude<deltaValueType, 'hex'> || 'rgb')
   else throw new Error(`${color1} type could not be infered if is string, otherwise type has not been provided as an option if passing a tuple`)
 
   if (isString(color2))
     color2 = getStringColorConvertion(color2)
   else if (isColorTuple(color2))
-    color1 = getTupleColorConvertion(color2, type as Exclude<deltaValueType, 'hex'>)
+    color2 = getTupleColorConvertion(color2, type as Exclude<deltaValueType, 'hex'> || 'rgb')
   else throw new Error(`${color2} type could not be infered if is string, otherwise type has not been provided as an option `)
 
   const value = deltaCache.get(JSON.stringify([color1, color2]))

--- a/src/isPerceivable.ts
+++ b/src/isPerceivable.ts
@@ -1,6 +1,5 @@
-import { isArray, isString } from 'yewtils'
 import { deltaE } from './deltaE'
-import type { ColorTuple, deltaValueType } from './types'
+import type { ColorTuple, InputTupleTypes } from './types'
 
 /**
  * checks if `first` would be noticebly different to the naked eye to `second`
@@ -10,17 +9,14 @@ import type { ColorTuple, deltaValueType } from './types'
 
 interface IsPerceivableOptions {
   threshold?: number
-  type?: deltaValueType
+  type?: InputTupleTypes
 }
 
 export function isPerceivable(first: ColorTuple, second: ColorTuple, options?: IsPerceivableOptions): boolean
 export function isPerceivable(first: string, second: string, options?: IsPerceivableOptions): boolean
 export function isPerceivable(first: unknown, second: unknown, options?: IsPerceivableOptions): boolean {
   const threshold = options?.threshold || 5
-  const type = options?.type
+  const type = options?.type || 'rgb'
 
-  if (!isArray(first) && !isArray(second) && isString(first) && isString(second))
-    return Math.round(deltaE(first, second)) > threshold
-
-  return Math.round(deltaE(first as ColorTuple, second as ColorTuple, type as deltaValueType)) > threshold
+  return Math.round(deltaE(first as any, second as any, type as any)) > threshold
 }

--- a/src/selector.ts
+++ b/src/selector.ts
@@ -1,11 +1,9 @@
-import { isString } from 'yewtils'
 import { isPerceivable } from './isPerceivable'
-import type { ColorTuple, deltaValueType } from './types'
-import { getColorConvertion } from './utils'
+import type { ColorTuple, InputTupleTypes } from './types'
 
 interface SelectorOptions {
   compare: ColorTuple | string
-  type?: deltaValueType
+  type?: InputTupleTypes
   threshold?: number
 }
 
@@ -22,11 +20,6 @@ const defaultOptions: Pick<Required<SelectorOptions>, 'threshold' | 'type'> = {
 export function selector(options: SelectorOptions, ...fallbacks: Array<ColorTuple | string>): ColorTuple | string {
   // eslint-disable-next-line prefer-const
   let { compare, threshold, type }: SelectorOptions = { ...defaultOptions, ...options }
-
-  if (isString(compare)) {
-    compare = getColorConvertion(compare)
-    type = undefined
-  }
 
   // TODO Better Typeing
 

--- a/src/sort.ts
+++ b/src/sort.ts
@@ -17,9 +17,7 @@ const sortMap: Record<'asc' | 'dec', (type?: Exclude<deltaValueType, 'hex'>) => 
 
 export function sort<T extends any[]>(comparitor: string | ColorTuple, toSort: T, option?: SortOptions): T {
   const direction = option?.direction || 'asc'
-  const type = option?.type
+  const type = option?.type || 'rgb'
 
-  const copy = Array.from(toSort)
-
-  return copy.sort(sortMap[direction](type)(comparitor)) as T
+  return Array.from(toSort).sort(sortMap[direction](type)(comparitor)) as T
 }

--- a/src/sort.ts
+++ b/src/sort.ts
@@ -15,9 +15,9 @@ const sortMap: Record<'asc' | 'dec', (type?: Exclude<deltaValueType, 'hex'>) => 
   },
 }
 
-export function sort<T extends any[]>(comparitor: string | ColorTuple, toSort: T, option?: SortOptions): T {
-  const direction = option?.direction || 'asc'
-  const type = option?.type || 'rgb'
+export function sort<T extends any[]>(comparitor: string | ColorTuple, toSort: T, options?: SortOptions): T {
+  const direction = options?.direction || 'asc'
+  const type = options?.type || 'rgb'
 
   return Array.from(toSort).sort(sortMap[direction](type)(comparitor)) as T
 }

--- a/src/sort.ts
+++ b/src/sort.ts
@@ -1,0 +1,25 @@
+import { deltaE } from './deltaE'
+import type { ColorTuple, deltaValueType } from './types'
+
+interface SortOptions {
+  direction?: 'asc' | 'dec'
+  type?: Exclude<deltaValueType, 'hex'>
+}
+
+const sortMap: Record<'asc' | 'dec', (type?: Exclude<deltaValueType, 'hex'>) => (comparitor: string | ColorTuple) => (a: any, b: any) => any> = {
+  asc: type => comparitor => (a, b) => {
+    return deltaE(comparitor as any, a, type) - deltaE(comparitor as any, b, type)
+  },
+  dec: type => comparitor => (a, b) => {
+    return deltaE(comparitor as any, b, type) - deltaE(comparitor as any, a, type)
+  },
+}
+
+export function sort<T extends any[]>(comparitor: string | ColorTuple, toSort: T, option?: SortOptions): T {
+  const direction = option?.direction || 'asc'
+  const type = option?.type
+
+  const copy = Array.from(toSort)
+
+  return copy.sort(sortMap[direction](type)(comparitor)) as T
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,3 +8,5 @@ export type RGBColorTuple = [number, number, number]
 export type LABColorTuple = [number, number, number]
 
 export type deltaValueType = 'rgb' | 'hex' | 'hsl' | 'lab'
+
+export type InputTupleTypes = 'rgb' | 'hsl' | 'lab'

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,4 @@
+import { isArray } from 'yewtils'
 import type { ColorTuple, RGBColorTuple, deltaValueType } from './types'
 
 /**
@@ -147,7 +148,7 @@ const stringConverstionMap: Record<deltaValueType, StringConversionFunction> = {
 
 const tupleConverstionMap: Record<Exclude<deltaValueType, 'hex'>, TupleConversionFunction > = {
   rgb: color => convertRGBToLAB(color),
-  hsl: color => stringConverstionMap.hsl(toHSLString(color)),
+  hsl: color => convertRGBToLAB(stringConverstionMap.hsl(toHSLString(color))),
   lab: color => color,
 }
 
@@ -176,5 +177,12 @@ export function getStringColorConvertion(color: string) {
 }
 
 export function getTupleColorConvertion(color: ColorTuple, type: Exclude<deltaValueType, 'hex'>) {
-  return tupleConverstionMap[type](color)
+  const res = tupleConverstionMap[type](color)
+  // console.log({ type, res })
+
+  return res
+}
+
+export function isColorTuple(possibleColorTuple: unknown): possibleColorTuple is RGBColorTuple {
+  return isArray(possibleColorTuple) && possibleColorTuple.length === 3
 }

--- a/test/deltaE.test.ts
+++ b/test/deltaE.test.ts
@@ -108,15 +108,7 @@ describe('DeltaE', () => {
     expect(+deltaE('hsl(0,0%,0%)', 'hsl(0,100%, 100%)').toPrecision(3)).toEqual(100)
   })
 
-  it('should accept hex strings', () => {
-    expect(deltaE('#ff0000', '#ff0000', 'hex')).toEqual(0)
-
-    expect(+deltaE('#ff0000', '#ff0077', 'hex').toPrecision(3)).toEqual(21.6)
-
-    expect(+deltaE('#000000', '#ffffff', 'hex').toPrecision(3)).toEqual(100)
-  })
-
-  it('should infer hex strings', () => {
+  it('should accept/infer hex strings', () => {
     expect(deltaE('#ff0000', '#ff0000')).toEqual(0)
 
     expect(+deltaE('#ff0000', '#ff0077').toPrecision(3)).toEqual(21.6)

--- a/test/isPerceivable.test.ts
+++ b/test/isPerceivable.test.ts
@@ -21,7 +21,7 @@ describe('isPerceivable', () => {
     expect(isPerceivable([0, 0, 0], [1, 1, 1])).toBe(false)
 
     expect(isPerceivable([0, 0, 0], [0, 0, 0])).toBe(false)
-    expect(isPerceivable([18, 19, 74], [8, 13, 78])).toBe(false)
+    expect(isPerceivable([18, 19, 74], [19, 20, 75], { type: 'rgb' })).toBe(false)
   })
 
   it('should take a third argument that changes the threshold', () => {

--- a/test/sort.test.ts
+++ b/test/sort.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { isArray } from 'yewtils'
+import { sort } from '../src/sort'
+
+describe('sort', () => {
+  it('should return an array', () => {
+    const arr = ['#000', '#fff', '#e2e', '#777']
+    expect(isArray(sort('#222', arr))).toBeTruthy()
+  })
+  it('should not mutate the origin array', () => {
+    const arr = ['#000', '#fff', '#e2e', '#777']
+    sort('#222', arr)
+    expect(arr).toMatchObject(['#000', '#fff', '#e2e', '#777'])
+  })
+  it('should return a sorted array', () => {
+    const arr = ['#000', '#fff', '#ddd', '#555']
+    expect(sort('#000', arr)).toMatchObject(['#000', '#555', '#ddd', '#fff'])
+  })
+  it('should accept options to ascending/descending order of sort', () => {
+    const arr = ['#000', '#fff', '#ddd', '#555']
+    expect(sort('#000', arr, { direction: 'dec' })).toMatchObject(['#fff', '#ddd', '#555', '#000'])
+    expect(sort('#000', arr, { direction: 'asc' })).toMatchObject(['#000', '#555', '#ddd', '#fff'])
+  })
+  it('should accept options to change the tuple type', () => {
+    const arr = ['#fff', [194, 242, 92], '#777', '#000']
+    expect(sort('#222', arr, { type: 'rgb' })).toMatchObject(['#000', '#777', '#fff', [194, 242, 92]])
+  })
+})


### PR DESCRIPTION
function to sort an array of colors, based on the perceived difference from a base comparator color.


### example 

```typescript
    const arr = ['#000', '#fff', '#ddd', '#555']


   // sorted by dec = sorts most different first (highest deltaE)
    sort('#000', arr, { direction: 'dec' }) // ['#fff', '#ddd', '#555', '#000']


   // sorted by asc = sorts most similar first (lowest deltaE)
    sort('#000', arr, { direction: 'asc' }) //['#000', '#555', '#ddd', '#fff']


 // if a tuple is being passed you will need to provide the color space of the tuple
    sort('#000', [
       '#000', 
       [255,255,255], 
       '#ddd',
       '#555'
    ], { direction: 'asc', type: 'rgb' }) //['#000', '#555', '#ddd', [255,255,255]]

```


closes #3