### PR TITLE
feat: add nocache params #2

### DIFF
--- a/src/deltaE.ts
+++ b/src/deltaE.ts
@@ -11,11 +11,11 @@ const deltaCache = new Map<string, number>()
  * more on delta-e: http://zschuessler.github.io/DeltaE/learn/
  */
 
-export function deltaE(color1: ColorTuple, color2: string, type: Exclude<deltaValueType, 'hex'>): number
-export function deltaE(color1: string, color2: ColorTuple, type: Exclude<deltaValueType, 'hex'>): number
-export function deltaE(color1: ColorTuple, color2: ColorTuple, type: Exclude<deltaValueType, 'hex'>): number
-export function deltaE(color1: string, color2: string, type?: Exclude<deltaValueType, 'hex'>): number
-export function deltaE(color1: unknown, color2: unknown, type: unknown): number {
+export function deltaE(color1: ColorTuple, color2: string, type: Exclude<deltaValueType, 'hex'>, nocache?: boolean): number
+export function deltaE(color1: string, color2: ColorTuple, type: Exclude<deltaValueType, 'hex'>, nocache?: boolean): number
+export function deltaE(color1: ColorTuple, color2: ColorTuple, type: Exclude<deltaValueType, 'hex'>, nocache?: boolean): number
+export function deltaE(color1: string, color2: string, type?: Exclude<deltaValueType, 'hex'>, nocache?: boolean): number
+export function deltaE(color1: unknown, color2: unknown, type: unknown, nocache?: boolean): number {
   if (isString(color1))
     color1 = getStringColorConvertion(color1)
   else if (isColorTuple(color1))
@@ -28,9 +28,11 @@ export function deltaE(color1: unknown, color2: unknown, type: unknown): number 
     color2 = getTupleColorConvertion(color2, type as Exclude<deltaValueType, 'hex'> || 'rgb')
   else throw new Error(`${color2} type could not be infered if is string, otherwise type has not been provided as an option `)
 
-  const value = deltaCache.get(JSON.stringify([color1, color2]))
-  if (value)
-    return value
+  if (!nocache) {
+    const value = deltaCache.get(JSON.stringify([color1, color2]))
+    if (value)
+      return value
+  }
 
   if (!isColorTuple(color1) || !isColorTuple(color2))
     throw new Error(`colors: ${color1} and ${color2} could type could not be infered or converted`)
@@ -55,7 +57,8 @@ export function deltaE(color1: unknown, color2: unknown, type: unknown): number 
 
   const result = i < 0 ? 0 : Math.sqrt(i)
 
-  deltaCache.set(JSON.stringify([color1, color2]), result)
+  if (!nocache)
+    deltaCache.set(JSON.stringify([color1, color2]), result)
 
   return result
 }

--- a/src/isPerceivable.ts
+++ b/src/isPerceivable.ts
@@ -11,13 +11,14 @@ import type { ColorTuple, InputTupleTypes } from './types'
 interface IsPerceivableOptions {
   threshold?: number
   type?: InputTupleTypes
+  nocache?: boolean
 }
 
-export function isPerceivable(first: ColorTuple, second: ColorTuple, options?: IsPerceivableOptions, nocache?: boolean): boolean
-export function isPerceivable(first: string, second: string, options?: IsPerceivableOptions, nocache?: boolean): boolean
-export function isPerceivable(first: unknown, second: unknown, options?: IsPerceivableOptions, nocache?: boolean): boolean {
+export function isPerceivable(first: ColorTuple, second: ColorTuple, options?: IsPerceivableOptions): boolean
+export function isPerceivable(first: string, second: string, options?: IsPerceivableOptions): boolean
+export function isPerceivable(first: unknown, second: unknown, options?: IsPerceivableOptions): boolean {
   const threshold = options?.threshold || 5
   const type = options?.type || 'rgb'
 
-  return Math.round(deltaE(first as any, second as any, type as any, nocache)) > threshold
+  return Math.round(deltaE(first as any, second as any, type as any, options?.nocache)) > threshold
 }

--- a/src/isPerceivable.ts
+++ b/src/isPerceivable.ts
@@ -5,6 +5,7 @@ import type { ColorTuple, InputTupleTypes } from './types'
  * checks if `first` would be noticebly different to the naked eye to `second`
  * returns true if they contrast enough,
  * threshold can be modified by `0 - 100` `(default = 5)`, to change how much difference the colors need to be
+ * nocache can be used to disable caching for color calculations
  */
 
 interface IsPerceivableOptions {
@@ -12,11 +13,11 @@ interface IsPerceivableOptions {
   type?: InputTupleTypes
 }
 
-export function isPerceivable(first: ColorTuple, second: ColorTuple, options?: IsPerceivableOptions): boolean
-export function isPerceivable(first: string, second: string, options?: IsPerceivableOptions): boolean
-export function isPerceivable(first: unknown, second: unknown, options?: IsPerceivableOptions): boolean {
+export function isPerceivable(first: ColorTuple, second: ColorTuple, options?: IsPerceivableOptions, nocache?: boolean): boolean
+export function isPerceivable(first: string, second: string, options?: IsPerceivableOptions, nocache?: boolean): boolean
+export function isPerceivable(first: unknown, second: unknown, options?: IsPerceivableOptions, nocache?: boolean): boolean {
   const threshold = options?.threshold || 5
   const type = options?.type || 'rgb'
 
-  return Math.round(deltaE(first as any, second as any, type as any)) > threshold
+  return Math.round(deltaE(first as any, second as any, type as any, nocache)) > threshold
 }


### PR DESCRIPTION
Sorry for making another PR, I forgot to pass the `nocache` parameter to the `isPerceivable()` method earlier.